### PR TITLE
Refactor: Update actions/cache to v4 and add keystore handling to And…

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -11,8 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JAVA_VERSION: 17
+      KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+      KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+      KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
     steps:
+      - name: Keystore Check
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: ${{ secrets.KEYSTORE_FILE_NAME }}
+          encodedString: ${{ secrets.KEYSTORE_FILE }}
+
+      - name: Set Keystore Path
+        run: echo "KEYSTORE_FILE=${{ steps.decode_keystore.outputs.filePath }}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/create_build.yml
+++ b/.github/workflows/create_build.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}


### PR DESCRIPTION
android build workflow

This commit updates the `actions/cache` action to version 4 in the `create_build.yml` workflow.

Additionally, it introduces keystore handling to the `android_build.yml` workflow by:
- Adding environment variables for keystore credentials (alias, password, key password).
- Incorporating a step to decode the base64 encoded keystore file.
- Setting the decoded keystore file path as an environment variable for use in subsequent steps.